### PR TITLE
feat: Internクラスの実装を追加

### DIFF
--- a/CPP_05/ex03/AForm.cpp
+++ b/CPP_05/ex03/AForm.cpp
@@ -1,0 +1,83 @@
+#include "AForm.hpp"
+
+AForm::AForm(const std::string &formName, int requiredSignGrade, int requiredExecGrade, const std::string &target)
+    : _formName(formName),
+      _isSigned(false),
+      _requiredSignGrade(requiredSignGrade),
+      _requiredExecGrade(requiredExecGrade),
+      _target(target)
+{
+    if (this->getRequiredExecGrade() < 1 || this->getRequiredSignGrade() < 1)
+    	throw AForm::GradeTooHighException();
+    if (this->getRequiredExecGrade() > 150 || this->getRequiredSignGrade() > 150)
+    	throw AForm::GradeTooLowException();
+}
+
+AForm::AForm(const AForm &other)
+    : _formName(other.getFormName()),
+      _isSigned(other.getIsSigned()),
+      _requiredSignGrade(other.getRequiredSignGrade()),
+      _requiredExecGrade(other.getRequiredExecGrade()),
+      _target(other.getTarget())
+{
+    if (this->getRequiredExecGrade() < 1 || this->getRequiredSignGrade() < 1)
+		throw AForm::GradeTooHighException();
+    if (this->getRequiredExecGrade() > 150 || this->getRequiredSignGrade() > 150)
+        throw AForm::GradeTooLowException();
+}
+
+AForm & AForm::operator=(const AForm &other) {
+    if (this != &other) {
+        this->_isSigned = other.getIsSigned();
+    }
+    return (*this);
+}
+
+AForm::~AForm(){};
+
+std::string const &AForm::getFormName() const {
+    return (this->_formName);
+};
+
+bool AForm::getIsSigned() const {
+    return (this->_isSigned);
+}
+
+int AForm::getRequiredSignGrade() const {
+    return (this->_requiredSignGrade);
+}
+
+int AForm::getRequiredExecGrade() const {
+    return (this->_requiredExecGrade);
+}
+
+std::string const &AForm::getTarget() const {
+    return (this->_target);
+};
+
+void AForm::beSigned(const Bureaucrat& b) {
+    if (this->getRequiredSignGrade() < b.getGrade()){
+        throw AForm::SignGradeTooLowException();
+    }
+    this->_isSigned = true;
+}
+
+void AForm::execute(const Bureaucrat& b) const {
+    if (!this->getIsSigned()){
+        throw AForm::FormNotSignedException();
+    }
+    if (this->getRequiredExecGrade() < b.getGrade()){
+        throw AForm::ExecGradeTooLowException();
+    }
+    doExecute(b);
+}
+
+std::ostream &operator<<(std::ostream &os, const AForm &value) {
+    os  << value.getFormName() 
+        << ", target: " << value.getTarget()
+        << ", signed: " << (value.getIsSigned() ? "Yes": "No")
+        << ", grade required to sign: " << value.getRequiredSignGrade()
+        << ", grade required to execute: " << value.getRequiredExecGrade()
+        << ".";
+    return (os);
+}

--- a/CPP_05/ex03/AForm.hpp
+++ b/CPP_05/ex03/AForm.hpp
@@ -1,0 +1,75 @@
+#ifndef AFORM_HPP
+#define AFORM_HPP
+
+#include <iostream>
+#include <string>
+#include "Bureaucrat.hpp"
+
+class AForm {
+    private:
+        const std::string 	_formName;
+        bool        		_isSigned;
+        const int         	_requiredSignGrade;
+        const int         	_requiredExecGrade;
+        const std::string 	_target;
+		AForm();
+
+    public:
+        // Orthodox Canonical Form
+        AForm(const std::string& formName, int requiredSignGrade, int requiredExecGrade, const std::string &target);
+        AForm(const AForm &other);
+        AForm &operator=(const AForm &other);
+        virtual ~AForm();
+        
+        // getter func
+        std::string const &getFormName() const;
+        bool getIsSigned() const;
+        int  getRequiredSignGrade() const;
+        int  getRequiredExecGrade() const;
+		std::string const &getTarget() const;
+        
+        // member func
+        void beSigned(const Bureaucrat& b);
+		void execute(const Bureaucrat& b) const;
+
+		// pure virtual func
+		virtual void doExecute(const Bureaucrat& b) const = 0 ;
+
+        // exception class
+        class GradeTooHighException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("AForm::GradeTooHighException: Grade is too high (grade < 1)!");
+                }
+        };
+        class GradeTooLowException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("AForm::GradeTooLowException: Grade is too low (grade > 150)!");
+                }
+        };
+        class SignGradeTooLowException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("AForm::GradeTooLowException: Grade is too low to sign form!");
+                }
+        };
+        class ExecGradeTooLowException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("AForm::ExecGradeTooLowException: Grade is too low to execute form!");
+                }
+        };
+        class FormNotSignedException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("AForm::FormNotSignedException: Form is not Signed!");
+                }
+        };
+
+};
+
+// outstream
+std::ostream& operator<<(std::ostream &os, const AForm &value);
+
+#endif

--- a/CPP_05/ex03/Bureaucrat.cpp
+++ b/CPP_05/ex03/Bureaucrat.cpp
@@ -1,0 +1,68 @@
+#include "Bureaucrat.hpp"
+#include "AForm.hpp"
+
+Bureaucrat::Bureaucrat(const std::string &name, int grade) : _name(name), _grade(grade) {
+    if (this->getGrade() < 1)
+        throw Bureaucrat::GradeTooHighException();
+    else if (this->getGrade() > 150)
+        throw Bureaucrat::GradeTooLowException();
+}
+
+Bureaucrat::Bureaucrat(const Bureaucrat &other) : _name(other.getName()), _grade(other.getGrade()) {
+    if (this->getGrade() < 1)
+        throw Bureaucrat::GradeTooHighException();
+    else if (this->getGrade() > 150)
+        throw Bureaucrat::GradeTooLowException();
+}
+
+Bureaucrat& Bureaucrat::operator=(const Bureaucrat &other) {
+    if (this != &other) {
+        this->_grade = other._grade;
+    }
+    return (*this);
+}
+
+Bureaucrat::~Bureaucrat(){}
+
+const std::string& Bureaucrat::getName() const {
+    return (this->_name);
+}
+
+int Bureaucrat::getGrade() const {
+    return (this->_grade);
+}
+
+void Bureaucrat::incrementGrade() {
+    if (this->getGrade() <= 1)
+        throw Bureaucrat::GradeTooHighException();
+    this->_grade--;
+}
+
+void Bureaucrat::decrementGrade(){
+    if (this->getGrade() >= 150)
+        throw Bureaucrat::GradeTooLowException();
+    this->_grade++;
+}
+
+void Bureaucrat::signForm(AForm& form) const {
+     try {
+        form.beSigned(*this);
+        std::cout << this->getName() << " signed " << form.getFormName() << std::endl;
+    } catch (const std::exception &e) {
+        std::cout << this->getName() << " couldn't sign " << form.getFormName() << " because " << e.what() << std::endl;
+    }
+}
+
+void Bureaucrat::executeForm(const AForm& form) const {
+    try {
+        form.execute(*this);
+        std::cout << this->getName() << " executed " << form.getFormName() << std::endl; 
+    } catch (const std::exception &e){
+        std::cout << this->getName() << " couldn't execute " << form.getFormName() << " because " << e.what() << std::endl;
+    }
+}
+
+std::ostream &operator<<(std::ostream &os, const Bureaucrat &value){
+    os << value.getName() << ", bureaucrat grade " << value.getGrade() << ".";
+    return (os);
+}

--- a/CPP_05/ex03/Bureaucrat.hpp
+++ b/CPP_05/ex03/Bureaucrat.hpp
@@ -1,0 +1,47 @@
+#ifndef BUREAUCRAT_HPP
+#define BUREAUCRAT_HPP
+
+#include <iostream>
+#include <string>
+
+class AForm;
+
+class Bureaucrat {
+    private:
+        const std::string _name;
+        int _grade;    
+        Bureaucrat();
+
+    public:
+        //  Orthodox Canonical Form準拠
+        Bureaucrat(const std::string &name, int grade);
+        Bureaucrat(const Bureaucrat &other);
+        Bureaucrat& operator=(const Bureaucrat &other);
+        ~Bureaucrat();
+
+        //　member function
+        const std::string& getName() const;
+        int getGrade() const;
+        void incrementGrade();
+        void decrementGrade();
+        void signForm(AForm& form) const;  
+        void executeForm(const AForm& form) const;
+
+        // exception class
+        class GradeTooHighException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("Bureaucrat::GradeTooHighException: Grade is too high (grade < 1)!");
+                }
+        };
+        class GradeTooLowException : public std::exception {
+            public:
+                virtual const char * what() const throw() {
+                    return ("Bureaucrat::GradeTooLowException: Grade is too low (grade > 150)!");
+                }
+        };
+};
+
+std::ostream& operator<<(std::ostream &os, const Bureaucrat &value);
+
+#endif

--- a/CPP_05/ex03/Intern.cpp
+++ b/CPP_05/ex03/Intern.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include "Intern.hpp"
+#include "ShrubberyCreationForm.hpp"
+#include "RobotomyRequestForm.hpp"
+#include "PresidentialPardonForm.hpp"
+
+Intern::Intern(){}
+
+Intern::~Intern(){}
+
+AForm* Intern::createShrubbery(const std::string& target){
+    return new ShrubberyCreationForm(target);
+}
+
+AForm* Intern::createRobotomy(const std::string& target){
+    return new RobotomyRequestForm(target);
+}
+
+AForm* Intern::createPardon(const std::string& target){
+    return new PresidentialPardonForm(target);
+}
+
+
+AForm* Intern::makeForm(const std::string& name, const std::string& target){
+    static const std::string formNames[] = {
+        "shrubbery creation",
+        "robotomy request",
+        "presidential pardon"
+    };
+
+    static const Intern::Creator creators[] = {
+        &Intern::createShrubbery,
+        &Intern::createRobotomy,
+        &Intern::createPardon
+    };
+
+    const size_t N = sizeof(formNames) / sizeof(formNames[0]);
+
+    for (size_t i = 0; i < N; i++) {
+        if (name == formNames[i]){
+            std::cout << "Intern creates " << name << std::endl;
+            return creators[i](target);
+        }
+    }
+    std::cout 	<< "Intern couldn't create " << name 
+				<< " because form name is invali." <<std::endl;
+    return (NULL);
+}

--- a/CPP_05/ex03/Intern.hpp
+++ b/CPP_05/ex03/Intern.hpp
@@ -1,0 +1,23 @@
+#ifndef INTERN_HPP
+#define INTERN_HPP
+
+#include <string>
+
+class AForm;
+
+class Intern {
+    private:
+        Intern(const Intern& other);
+        Intern& operator=(const Intern& other);
+
+    public:
+        Intern();
+        ~Intern();
+        typedef AForm* (*Creator)(const std::string& target);
+        static AForm* createShrubbery(const std::string& target);
+        static AForm* createRobotomy(const std::string& target);
+        static AForm* createPardon(const std::string& target);
+        AForm* makeForm(const std::string& name, const std::string& target);
+};
+
+#endif

--- a/CPP_05/ex03/Makefile
+++ b/CPP_05/ex03/Makefile
@@ -1,0 +1,100 @@
+CPP       = c++
+CPP_FLAGS = -Wall -Werror -Wextra -std=c++98
+
+PROGRAM_NAME = ex03
+
+# ========= source =========
+SRCDIR   := ./
+INCDIR   := ./
+INCLUDES := -I$(INCDIR)
+
+SRC :=  $(SRCDIR)/main.cpp \
+        $(SRCDIR)/Bureaucrat.cpp \
+        $(SRCDIR)/AForm.cpp \
+		$(SRCDIR)/ShrubberyCreationForm.cpp \
+		$(SRCDIR)/RobotomyRequestForm.cpp \
+		$(SRCDIR)/PresidentialPardonForm.cpp \
+		$(SRCDIR)/Intern.cpp
+
+OBJDIR      := objs
+TEST_OBJDIR := test_objs
+TEST_BINDIR := bin_tests
+
+OBJS := $(SRC:$(SRCDIR)/%.cpp=$(OBJDIR)/%.o)
+
+# ========= tests =========
+TESTDIR    := tests
+TEST_NAMES := test_01_constructors \
+              test_02_stream_operators \
+              test_03_grade_change \
+              test_04_beSigned \
+              test_05_signForm \
+			  test_06_executeForm \
+			  test_07_intern
+
+# 重要：出力先は TEST_BINDIR にする
+TEST_BINS  := $(addprefix $(TEST_BINDIR)/,$(TEST_NAMES))
+
+HELPERS_SRC := $(TESTDIR)/helpers.cpp
+HELPERS_OBJ := $(TEST_OBJDIR)/helpers.o
+
+# ========= default =========
+all: $(PROGRAM_NAME)
+
+$(PROGRAM_NAME): $(OBJS)
+	$(CPP) $(CPP_FLAGS) $(INCLUDES) -o $@ $^
+
+$(OBJDIR):
+	@mkdir -p $(OBJDIR)
+
+$(OBJDIR)/%.o: $(SRCDIR)/%.cpp | $(OBJDIR)
+	$(CPP) $(CPP_FLAGS) $(INCLUDES) -c $< -o $@
+
+# ===== make dirs (一度だけ定義する) =====
+$(TEST_OBJDIR):
+	@mkdir -p $(TEST_OBJDIR)
+
+$(TEST_BINDIR):
+	@mkdir -p $(TEST_BINDIR)
+
+# ===== helpers (テスト用オブジェクト) =====
+$(HELPERS_OBJ): $(HELPERS_SRC) | $(TEST_OBJDIR)
+	$(CPP) $(CPP_FLAGS) $(INCLUDES) -c $< -o $@
+
+# ===== per-test template =====
+define BUILD_TEST_template
+# compile -> test_objs/<name>.o
+$(TEST_OBJDIR)/$(1).o: $(TESTDIR)/$(1).cpp | $(TEST_OBJDIR)
+	$(CPP) $(CPP_FLAGS) $(INCLUDES) -c $$< -o $$@
+
+# link -> bin_tests/<name>
+$(TEST_BINDIR)/$(1): $(TEST_OBJDIR)/$(1).o $(HELPERS_OBJ) $(filter-out $(OBJDIR)/main.o,$(OBJS)) | $(TEST_BINDIR)
+	$(CPP) $(CPP_FLAGS) $(INCLUDES) -o $$@ $$^
+endef
+$(foreach t,$(TEST_NAMES),$(eval $(call BUILD_TEST_template,$(t))))
+
+# ===== build & run =====
+build-tests: $(TEST_BINS)
+
+run-tests: $(TEST_BINS)
+	@set -e; \
+	for t in $(TEST_BINS); do \
+		echo "===== Running $$t ====="; \
+		./$$t; \
+	done
+
+# run single: make run-test_02_stream_operators
+run-%: $(TEST_BINDIR)/%
+	./$<
+
+# ===== clean =====
+clean:
+	rm -rf $(OBJDIR) $(TEST_OBJDIR)
+
+fclean: clean
+	rm -f $(PROGRAM_NAME)
+	rm -rf $(TEST_BINDIR)
+
+re: fclean all
+
+.PHONY: all clean fclean re build-tests run-tests run-%

--- a/CPP_05/ex03/PresidentialPardonForm.cpp
+++ b/CPP_05/ex03/PresidentialPardonForm.cpp
@@ -1,0 +1,21 @@
+#include "PresidentialPardonForm.hpp"
+
+PresidentialPardonForm::PresidentialPardonForm(const std::string &target)
+    : AForm("PresidentialPardonForm", 25, 5, target) {}
+
+PresidentialPardonForm::PresidentialPardonForm(const PresidentialPardonForm &other)
+    : AForm(other) {}
+
+PresidentialPardonForm& PresidentialPardonForm::operator=(const PresidentialPardonForm &other){
+    if (this != &other) {
+        AForm::operator=(other);
+    }
+    return (*this);
+} 
+
+PresidentialPardonForm::~PresidentialPardonForm(){}
+
+void PresidentialPardonForm::doExecute(const Bureaucrat& b) const {
+    (void)b;
+    std::cout <<  this->getTarget() << " has been pardoned by Zaphod Beeblebrox." << std::endl;
+}

--- a/CPP_05/ex03/PresidentialPardonForm.hpp
+++ b/CPP_05/ex03/PresidentialPardonForm.hpp
@@ -1,0 +1,19 @@
+#ifndef PRESIDENTIALPARDONFORM_HPP
+#define PRESIDENTIALPARDONFORM_HPP
+
+#include "AForm.hpp"
+
+class Bureaucrat;
+
+class PresidentialPardonForm : public AForm {
+    private:
+        PresidentialPardonForm();
+    public:
+        PresidentialPardonForm(const std::string& target);
+        PresidentialPardonForm(const PresidentialPardonForm& other);
+        PresidentialPardonForm& operator=(const PresidentialPardonForm& other);
+        ~PresidentialPardonForm();
+        void doExecute(const Bureaucrat& b) const ;
+};
+
+#endif

--- a/CPP_05/ex03/RobotomyRequestForm.cpp
+++ b/CPP_05/ex03/RobotomyRequestForm.cpp
@@ -1,0 +1,36 @@
+#include "RobotomyRequestForm.hpp"
+#include <cstdlib> 
+#include <ctime> 
+
+RobotomyRequestForm::RobotomyRequestForm(const std::string &target)
+    : AForm("RobotomyRequestForm", 72, 45, target) {}
+
+RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &other)
+    : AForm(other) {}
+
+RobotomyRequestForm& RobotomyRequestForm::operator=(const RobotomyRequestForm &other){
+    if (this != &other) {
+        AForm::operator=(other);
+    }
+    return (*this);
+} 
+
+RobotomyRequestForm::~RobotomyRequestForm(){}
+
+void RobotomyRequestForm::doExecute(const Bureaucrat& b) const {
+    (void)b;
+    std::cout << "* drilling noises *" << std::endl;
+
+    static bool seed_is_set = false;
+    if (!seed_is_set){
+        std::srand(std::time(NULL));
+        seed_is_set = true;
+    }
+
+    if (std::rand() % 2 == 0) {
+        std::cout <<  this->getTarget() << " has been robotomized successfully." << std::endl;
+    }
+    else {
+        std::cout << "Robotomy failed on " << this->getTarget() << "." << std::endl;
+    }
+}

--- a/CPP_05/ex03/RobotomyRequestForm.hpp
+++ b/CPP_05/ex03/RobotomyRequestForm.hpp
@@ -1,0 +1,19 @@
+#ifndef ROBOTOMYREQUESTFORM_HPP
+#define ROBOTOMYREQUESTFORM_HPP
+
+#include "AForm.hpp"
+
+class Bureaucrat;
+
+class RobotomyRequestForm : public AForm {
+    private:
+        RobotomyRequestForm();
+    public:
+        RobotomyRequestForm(const std::string& target);
+        RobotomyRequestForm(const RobotomyRequestForm& other);
+        RobotomyRequestForm& operator=(const RobotomyRequestForm& other);
+        ~RobotomyRequestForm();
+        void doExecute(const Bureaucrat& b) const ;
+};
+
+#endif

--- a/CPP_05/ex03/ShrubberyCreationForm.cpp
+++ b/CPP_05/ex03/ShrubberyCreationForm.cpp
@@ -1,0 +1,52 @@
+#include "ShrubberyCreationForm.hpp"
+#include <fstream>
+
+ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target)
+    : AForm("ShrubberyCreationForm", 145, 137, target) {}
+
+ShrubberyCreationForm::ShrubberyCreationForm(const ShrubberyCreationForm &other)
+    : AForm(other) {}
+
+ShrubberyCreationForm& ShrubberyCreationForm::operator=(const ShrubberyCreationForm &other){
+    if (this != &other) {
+        AForm::operator=(other);
+    }
+    return (*this);
+} 
+
+ShrubberyCreationForm::~ShrubberyCreationForm(){}
+
+void ShrubberyCreationForm::doExecute(const Bureaucrat& b) const {
+    (void)b;
+    
+    std::ofstream ofs((this->getTarget() + "_shrubbery").c_str());
+    if (!ofs){
+        std::cerr << "Failed to open file" << std::endl;
+        return ;
+    }
+    ofs << "                /\\\n";
+    ofs << "               /**\\\n";
+    ofs << "              /****\\\n";
+    ofs << "             /******\\\n";
+    ofs << "            /********\\\n";
+    ofs << "           /**********\\\n";
+    ofs << "          /************\\\n";
+    ofs << "         /**************\\\n";
+    ofs << "        /****************\\\n";
+    ofs << "       /******************\\\n";
+    ofs << "      /********************\\\n";
+    ofs << "     /**********************\\\n";
+    ofs << "    /************************\\\n";
+    ofs << "   /**************************\\\n";
+    ofs << "  /****************************\\\n";
+    ofs << " /******************************\\\n";
+    ofs << "/********************************\\\n";
+    ofs << "              ||||||||||\n";
+    ofs << "              ||||||||||\n";
+    ofs << "              ||||||||||\n";
+    ofs << "              ||||||||||\n";
+    ofs << "              ||||||||||\n";
+    ofs << "              ||||||||||\n";
+    ofs << "          ____||||||||____\n";
+    ofs << "         /________________\\\n";
+}

--- a/CPP_05/ex03/ShrubberyCreationForm.hpp
+++ b/CPP_05/ex03/ShrubberyCreationForm.hpp
@@ -1,0 +1,19 @@
+#ifndef SHRUBBERYCREATIONFORM_HPP
+#define SHRUBBERYCREATIONFORM_HPP
+
+#include "AForm.hpp"
+
+class Bureaucrat;
+
+class ShrubberyCreationForm : public AForm {
+    private:
+        ShrubberyCreationForm();
+    public:
+        ShrubberyCreationForm(const std::string& target);
+        ShrubberyCreationForm(const ShrubberyCreationForm& other);
+        ShrubberyCreationForm& operator=(const ShrubberyCreationForm& other);
+        ~ShrubberyCreationForm();
+        void doExecute(const Bureaucrat& b) const ;
+};
+
+#endif

--- a/CPP_05/ex03/main.cpp
+++ b/CPP_05/ex03/main.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include "Intern.hpp"
+#include "AForm.hpp"
+
+int main() {
+    Intern someRandomIntern;
+
+    // テスト対象フォーム名
+    std::string validForms[] = {
+        "shrubbery creation",
+        "robotomy request",
+        "presidential pardon"
+    };
+    std::string invalidForm = "invalid form";
+
+    // 正しいフォーム名で生成できるか確認
+    for (int i = 0; i < 3; ++i) {
+        AForm* form = someRandomIntern.makeForm(validForms[i], "Target_" + std::to_string(i));
+        if (form) {
+            std::cout << "Success: " << validForms[i] << " created." << std::endl;
+            delete form; // メモリリーク防止
+        } else {
+            std::cout << "Error: " << validForms[i] << " was not created." << std::endl;
+        }
+        std::cout << "-----------------------------" << std::endl;
+    }
+
+    // 無効なフォーム名で NULL が返るか確認
+    AForm* badForm = someRandomIntern.makeForm(invalidForm, "Nobody");
+    if (!badForm) {
+        std::cout << "Correct: invalid form returned NULL." << std::endl;
+    } else {
+        std::cout << "Error: invalid form should not be created." << std::endl;
+        delete badForm;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Intern.hpp / Intern.cpp を作成
- 関数ポインタ用の typedef Creator を定義
- 静的生成関数を実装:
  - createShrubbery
  - createRobotomy
  - createPardon
- makeForm を実装（フォーム名と生成関数の対応テーブルを利用）
- 無効なフォーム名の場合はエラーメッセージを出力し NULL を返すように変更